### PR TITLE
Fix capitalization in L<...> so links work in HTML.

### DIFF
--- a/lib/Catalyst/Manual/ExtendingCatalyst.pod
+++ b/lib/Catalyst/Manual/ExtendingCatalyst.pod
@@ -238,7 +238,7 @@ array reference. As you can see, you can use attributes to configure
 your actions. You can specify or alter these attributes via
 L</"Component Configuration">, or even react on them as soon as
 Catalyst encounters them by providing your own L<component base
-class|/"Component Base Classes">.
+class|/"Component base classes">.
 
 =head2 Component Configuration
 


### PR DESCRIPTION
The in-page link to "Component Base Classes" subheading doesn't work on both search.cpan.org and metacpan.org under the Attributes section.

This is because HTML anchors are apparently case sensitive.

See http://search.cpan.org/~ether/Catalyst-Manual-5.9007/lib/Catalyst/Manual/ExtendingCatalyst.pod#Attributes and try to click on the link at the end of "...Catalyst encounters them by providing your own component base class."
